### PR TITLE
Fix osquery class parameters

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -1,17 +1,13 @@
 # class osquery::config - manage json config in /etc/osquery
-class osquery::config (
+class osquery::config {
 
-  $settings = $::osquery::params::settings,
-
-){
-
-  file { $::osquery::params::config:
+  file { $::osquery::config:
     ensure  => present,
     owner   => root,
     group   => root,
-    content => sorted_json($::settings), # array to JSON lib
-    require => Package[$::osquery::params::package_name],
-    notify  => Service[$::osquery::params::service_name],
+    content => sorted_json($::osquery::settings), # array to JSON lib
+    require => Package[$::osquery::package_name],
+    notify  => Service[$::osquery::service_name],
   }
 
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -10,11 +10,17 @@
 # [*package_ver*]
 #   Package to ensure exists, can be latest or present. Default is latest.
 #
+# [*service_enable*]
+#   Enable or disable the osqueryd service. Default is true.
+#
 # [*service_name*]
 #   Package service name to be ran. Default is auto detect.
 #
 # [*settings_name*]
 #   Hash of the OSquery settings to be converted automatically into a JSON string for the config file.
+#
+# [*repo_install*]
+#   Whether or not to install the osquery yum/apt repository. Default is true.
 #
 # === Variables
 #
@@ -51,17 +57,20 @@
 #
 class osquery (
 
-  $package_name = $::osquery::params::package_name,
-  $service_name = $::osquery::params::service_name,
-  $package_ver  = $::osquery::params::package_ver,
-  $settings     = $::osquery::params::settings,
+  $package_name   = $::osquery::params::package_name,
+  $service_name   = $::osquery::params::service_name,
+  $package_ver    = $::osquery::params::package_ver,
+  $service_enable = $::osquery::params::service_enable,
+  $settings       = $::osquery::params::settings,
+  $repo_install   = $::osquery::params::repo_install,
 
 ) inherits ::osquery::params {
 
   validate_string($package_name)
   validate_string($service_name)
-  validate_re($package_ver, [ 'latest', 'present' ])
+  validate_bool($service_enable)
   validate_hash($settings)
+  validate_bool($repo_install)
 
   class { '::osquery::install': } ->
   class { '::osquery::config': } ~>

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,29 +1,29 @@
 # osquery::install - installation class
 class osquery::install {
 
-  if $::osquery::params::repo_install {
+  if $::osquery::repo_install {
     case $::operatingsystem {
       'ubuntu': {
 
         apt::source { 'osquery_repo':
-          location => $::osquery::params::repo_url,
+          location => $::osquery::repo_url,
           repos    => 'main',
           key      => {
-            'id'     => $::osquery::params::repo_key_id,
-            'server' => $::osquery::params::repo_key_server,
+            'id'     => $::osquery::repo_key_id,
+            'server' => $::osquery::repo_key_server,
           },
-          before   => Package[$::osquery::params::package_name],
+          before   => Package[$::osquery::package_name],
         }
 
       }
       'RedHat', 'Amazon', 'CentOS', 'Scientific', 'OracleLinux': {
 
         # Redhat clone flavors
-        package { $::osquery::params::repo_name:
+        package { $::osquery::repo_name:
           ensure   => present,
-          source   => $::osquery::params::repo_url,
+          source   => $::osquery::repo_url,
           provider => 'rpm',
-          before   => Package[$::osquery::params::package_name],
+          before   => Package[$::osquery::package_name],
         }
 
       }
@@ -37,8 +37,8 @@ class osquery::install {
   # OSQuery package installation
   #
 
-  package { $::osquery::params::package_name:
-    ensure => $::osquery::params::package_ver,
+  package { $::osquery::package_name:
+    ensure => $::osquery::package_ver,
   }
 
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -19,11 +19,12 @@ class osquery::params {
     },
   }
 
-  $package_name = 'osquery'
-  $service_name = 'osqueryd'
-  $package_ver  = 'latest' # or present
-  $config       = '/etc/osquery/osquery.conf'
-  $repo_install = true
+  $package_name   = 'osquery'
+  $service_name   = 'osqueryd'
+  $package_ver    = 'latest' # or present
+  $service_enable = true
+  $config         = '/etc/osquery/osquery.conf'
+  $repo_install   = true
 
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Amazon', 'Scientific', 'OracleLinux', 'OEL': {

--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -1,12 +1,12 @@
 # osquery::service - manage services
 class osquery::service {
 
-  service { $::osquery::params::service_name:
-    ensure     => running,
-    enable     => true,
+  service { $::osquery::service_name:
+    ensure     => $::osquery::service_enable,
+    enable     => $::osquery::service_enable,
     hasstatus  => true,
     hasrestart => true,
-    require    => Package[$::osquery::params::package_name],
+    require    => Package[$::osquery::package_name],
   }
 
 }


### PR DESCRIPTION
I noticed that, although there were class parameters on the init class, these values weren't actually used by anything else since all other classes reference them under params class explicitly. This change references the variables from the init class rather than params.

In addition, I added a "repo_install" class parameter, and a new "service_enable" variable and parameter.