### PR TITLE
Support for Windows

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,8 +3,8 @@ class osquery::config {
 
   file { $::osquery::config:
     ensure  => present,
-    owner   => $::osquery::conf_owner,
-    group   => $::osquery::conf_group,
+    owner   => $::osquery::config_owner,
+    group   => $::osquery::config_group,
     content => sorted_json($::osquery::settings), # array to JSON lib
     require => Package[$::osquery::package_name],
     notify  => Service[$::osquery::service_name],

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -3,8 +3,8 @@ class osquery::config {
 
   file { $::osquery::config:
     ensure  => present,
-    owner   => root,
-    group   => root,
+    owner   => $::osquery::conf_owner,
+    group   => $::osquery::conf_group,
     content => sorted_json($::osquery::settings), # array to JSON lib
     require => Package[$::osquery::package_name],
     notify  => Service[$::osquery::service_name],

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -27,6 +27,13 @@ class osquery::install {
         }
 
       }
+      'Windows': {
+        package{ 'osquery':
+          ensure          => present,
+          provider        => chocolatey,
+          install_options => ['-params','"','/InstallService','"'],
+        }
+      }
       default: {
         fail("${::operatingsystem} not supported")
       }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -23,8 +23,20 @@ class osquery::params {
   $service_name   = 'osqueryd'
   $package_ver    = 'latest' # or present
   $service_enable = true
-  $config         = '/etc/osquery/osquery.conf'
   $repo_install   = true
+
+  case $::kernel {
+    'Windows': { 
+      $config       = 'C:\ProgramData\osquery\osquery.conf',
+      $config_user  = 'SYSTEM',
+      $config_group = 'Administrators',
+    }
+    default: { 
+      $config       = '/etc/osquery/osquery.conf' 
+      $config_user  = 'root',
+      $config_group = 'root',
+    }
+  }
 
   case $::operatingsystem {
     'RedHat', 'CentOS', 'Amazon', 'Scientific', 'OracleLinux', 'OEL': {


### PR DESCRIPTION
This would add a dependency for windows nodes on the chocolatey puppet package provider from  https://github.com/chocolatey/puppet-chocolatey 