### PR TITLE
Pass format through to pack config, fix var name

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -4,6 +4,7 @@ class osquery::config (
   $format = 'simple'
 
 ){
+  include '::stdlib'
 
   file { $::osquery::config:
     ensure  => present,
@@ -17,7 +18,7 @@ class osquery::config (
   if has_key($::osquery::settings, 'packs') {
     $packs = keys($::osquery::settings['packs'])
     osquery_config { $packs:
-      #format => $format,
+      format => $format,
     }
   }
 }

--- a/manifests/pack_config.pp
+++ b/manifests/pack_config.pp
@@ -8,7 +8,7 @@ define osquery::pack(
 ) {
 
   # Get the input from hiera
-  if $pack_config {
+  if $pack_input {
     file { $pack_file:
       ensure  => present,
       owner   => $owner,


### PR DESCRIPTION
We must include stdlib to get has_key()
Uncommented format now that it is available by other PR
Fixed a var name mismatch I introduced :(