### PR TITLE
Rename sorted_json to osquery_sorted_json

### DIFF
--- a/lib/puppet/parser/functions/osquery_sorted_json.rb
+++ b/lib/puppet/parser/functions/osquery_sorted_json.rb
@@ -47,16 +47,16 @@ def pretty_sorted_json(obj, indent=0)
 end
 
 module Puppet::Parser::Functions
-  newfunction(:sorted_json, :type => :rvalue, :doc => <<-EOS
+  newfunction(:osquery_sorted_json, :type => :rvalue, :doc => <<-EOS
 This function takes data, outputs making sure the hash keys are sorted
 
 *Examples:*
 
-    sorted_json({'key'=>'value'})
+    osquery_sorted_json({'key'=>'value'}, 'simple')
 
 Would return: {'key':'value'}
 
-    sorted_json({'key'=> ['value','another']}, 'pretty')
+    osquery_sorted_json({'key'=> ['value','another']}, 'pretty')
 
 Would return:
 {
@@ -67,14 +67,16 @@ Would return:
 }
     EOS
   ) do |arguments|
-    raise(Puppet::ParseError, "sorted_json(): Wrong number of arguments " +
+    raise(Puppet::ParseError, "osquery_sorted_json(): Wrong number of arguments " +
       "given (#{arguments.size} for 2)") if arguments.size != 2
 
     input = arguments[0]
     if arguments[1] == 'pretty'
       return pretty_sorted_json(input)
-    else
+    elsif arguments[1] == 'simple'
       return sorted_json(input)
+    else
+      raise(Puppet::ParseError, "osquery_sorted_json(): Invalid format given")
     end
   end
 end

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -8,7 +8,7 @@ class osquery::config (
 
   file { $::osquery::config:
     ensure  => present,
-    content => sorted_json($::osquery::settings, $format), # format as JSON
+    content => osquery_sorted_json($::osquery::settings, $format), # format as JSON
     owner   => $::osquery::config_owner,
     group   => $::osquery::config_group,
     require => Package[$::osquery::package_name],

--- a/manifests/pack.pp
+++ b/manifests/pack.pp
@@ -13,7 +13,7 @@ define osquery::pack(
       ensure  => present,
       owner   => $owner,
       group   => $group,
-      content => sorted_json($pack_input, $format), # convert to JSON
+      content => osquery_sorted_json($pack_input, $format), # convert to JSON
       require => Package[$::osquery::package_name],
       notify  => Service[$::osquery::service_name],
     }


### PR DESCRIPTION
I found that the `sorted_json` function conflicts with another function with the same name in our environment (Puppet 4.5.2). This is also documented (here)[https://puppet.com/docs/puppet/4.10/dirs_modulepath.html#duplicate-or-conflicting-modules-and-content]:

> However, Puppet occasionally shows problematic behavior with Ruby plugins loaded directly from modules. This includes:
> * Plugins used by the Puppet master (custom resource types, custom functions)

This fix simply renames the function from `sorted_json` to `osquery_sorted_json`.

