### PR TITLE
fix install ordering

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,60 +1,68 @@
 # osquery::install - installation class
 class osquery::install {
 
-  # repo install [optional]
-  if $::osquery::repo_install {
-    case $::operatingsystem {
-      'ubuntu': {
-
-        apt::source { 'osquery_repo':
-          location => $::osquery::repo_url,
-          repos    => 'main',
-          key      => {
-            'id'     => $::osquery::repo_key_id,
-            'server' => $::osquery::repo_key_server,
-          },
-          before   => Package[$::osquery::package_name],
-        }
-
-      }
-      'RedHat', 'Amazon', 'CentOS', 'Scientific', 'OracleLinux': {
-
-        # Redhat clone flavors
-        package { $::osquery::repo_name:
-          ensure   => present,
-          source   => $::osquery::repo_url,
-          provider => 'rpm',
-          before   => Package[$::osquery::package_name],
-        }
-
-      }
-      default: {
-        fail("${::operatingsystem} not supported")
-      }
-    } # end case $::osfamily
-  } # end if $::osquery::params::repo_install
-
-  # package install
+  # Installation methods vary for OS type and family 
   case $::kernel {
     'Linux': {
+      # repo install [optional]
+      if $::osquery::repo_install {
+        case $::osfamily {
+          'Debian': {
+            # add the osquery APT repo
+            apt::source { 'osquery_repo':
+              location => $::osquery::repo_url,
+              repos    => 'main',
+              key      => {
+                'id'     => $::osquery::repo_key_id,
+                'server' => $::osquery::repo_key_server,
+              },
+            }
 
-      package { $::osquery::package_name:
-        ensure => $::osquery::package_ver,
+            # install the osquery package after an apt-get update is run
+            package { $::osquery::package_name:
+              ensure  => $::osquery::package_ver,
+              require => Class['apt::update'],
+            }
+
+            # explicitly set ordering for installation of repo and package
+            Apt::Source['osquery_repo'] -> Package[$::osquery::package_name]
+          }
+          'RedHat': {
+            # add the osquery yum repo package
+            package { $::osquery::repo_name:
+              ensure   => present,
+              source   => $::osquery::repo_url,
+              provider => 'rpm',
+            }
+            # install the osquery package, requiring the yum repo package
+            package { $::osquery::package_name:
+              ensure  => $::osquery::package_ver,
+              require => Package[$::osquery::repo_name],
+            }
+            # explicitly set ordering for installation of repo and package
+            Package[$osquery::repo_name] -> Package[$::osquery::package_name]
+          }
+          default: {
+            fail("${::osfamily} not supported")
+          }
+        } # end case $::osfamily
+      } # end if $::osquery::repo_install
+      else {
+        # if not installing the repo, install the osquery package from existing repos
+        package { $::osquery::package_name:
+          ensure  => $::osquery::package_ver,
+        }
       }
-
     }
     'Windows': {
-
       package{ 'osquery':
         ensure          => present,
         provider        => chocolatey,
         install_options => ['-params','"','/InstallService','"'],
       }
-
     }
     default: {
-      fail("${::operatingsystem} not supported")
+      fail("${::kernel} not supported")
     }
   } # end case $::kernel
-
 }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -54,7 +54,7 @@ class osquery::install {
         }
       }
     }
-    'Windows': {
+    'windows': {
       package{ 'osquery':
         ensure          => present,
         provider        => chocolatey,

--- a/spec/classes/basic_spec.rb
+++ b/spec/classes/basic_spec.rb
@@ -5,6 +5,7 @@ describe 'osquery', :type => :class do
   describe "class on Redhat 6 family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'Redhat',
         :operatingsystemmajrelease => '6',
         :architecture => 'x86_64',
@@ -29,6 +30,7 @@ describe 'osquery', :type => :class do
   describe "class on Redhat 7 family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'Redhat',
         :operatingsystemmajrelease => '7',
         :architecture => 'x86_64',
@@ -53,6 +55,7 @@ describe 'osquery', :type => :class do
   describe "class on CentOS 6 family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'CentOS',
         :operatingsystemmajrelease => '6',
         :architecture => 'x86_64',
@@ -77,6 +80,7 @@ describe 'osquery', :type => :class do
   describe "class on CentOS 7 family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'CentOS',
         :operatingsystemmajrelease => '7',
         :architecture => 'x86_64',
@@ -101,6 +105,7 @@ describe 'osquery', :type => :class do
   describe "class on Scientific linux family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'Scientific',
         :operatingsystemmajrelease => '6',
         :architecture => 'x86_64',
@@ -125,6 +130,7 @@ describe 'osquery', :type => :class do
   describe "class on Amazon linux family with no parameters, basic test" do
     let :facts do
       {
+        :osfamily => 'RedHat',
         :operatingsystem => 'Amazon',
         :operatingsystemmajrelease => '6',
         :architecture => 'x86_64',


### PR DESCRIPTION
This PR changes the `osquery::install` class to work on 1st run of puppet agent on Linux agents.

Conditional logic updated to be based on facts `$::kernel` and then `$::osfamily` to catch the variety of Linux cases with specific logic for repo-then-package install ordering on apt-based and yum-based operating systems. 

spec/test updated, module also manually tested on debian, ubuntu, centos, oracle linux

Also update the Windows case to catch the fact name as reported by windows, with a lower-case 'w' per [FACT-620](https://tickets.puppetlabs.com/browse/FACT-620)