### PR TITLE
added compatibility for Debian 8,9

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -10,9 +10,11 @@ class osquery::install {
           'Debian': {
             # add the osquery APT repo
             apt::source { 'osquery_repo':
-              location => $::osquery::repo_url,
-              repos    => 'main',
-              key      => {
+              location     => $::osquery::repo_url,
+              architecture => $::architecture,
+              release      => 'deb',
+              repos        => 'main',
+              key          => {
                 'id'     => $::osquery::repo_key_id,
                 'server' => $::osquery::repo_key_server,
               },
@@ -21,11 +23,15 @@ class osquery::install {
             # install the osquery package after an apt-get update is run
             package { $::osquery::package_name:
               ensure  => $::osquery::package_ver,
-              require => Class['apt::update'],
             }
 
-            # explicitly set ordering for installation of repo and package
-            Apt::Source['osquery_repo'] -> Package[$::osquery::package_name]
+            package { 'apt-transport-https':
+              ensure => present,
+              notify => Class['apt::update'],
+            }
+
+            # explicitly set ordering for installation of package, repo and package
+            Package['apt-transport-https'] -> Apt::Source['osquery_repo'] -> Package[$::osquery::package_name]
           }
           'RedHat': {
             # add the osquery yum repo package

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -43,9 +43,8 @@ class osquery::params {
       $repo_name = "osquery-s3-centos${facts['os']['release']['major']}-repo"
       $repo_url  = "https://osquery-packages.s3.amazonaws.com/centos${facts['os']['release']['major']}/noarch/osquery-s3-centos${facts['os']['release']['major']}-repo-1-0.0.noarch.rpm"
     }
-    'ubuntu': {
-      # $lsbdistcodename fact example: 'trusty'
-      $repo_url        = "[arch=${::architecture}] https://pkg.osquery.io/deb deb main"
+    'Ubuntu', 'Debian': {
+      $repo_url        = 'https://pkg.osquery.io/deb'
       $repo_key_id     = '1484120AC4E9F8A1A577AEEE97A80C63C9D8B80B'
       $repo_key_server = 'keyserver.ubuntu.com'
     }

--- a/metadata.json
+++ b/metadata.json
@@ -27,6 +27,13 @@
       ]
     },
     {
+      "operatingsystem": "Debian",
+      "operatingsystemrelease": [
+        "8",
+        "9"
+      ]
+    },
+    {
       "operatingsystem": "CentOS",
       "operatingsystemrelease": [
         "6",


### PR DESCRIPTION
To be compatible with Debian we do need the package **apt-transport-https**. This package is not preinstalled on Debian 8 or 9.

In addition the general url of the repository must be used as suggested [here](https://osquery.io/downloads/)

Before:
```
/etc/apt/sources.list.d/osquery_repo.list:
deb [arch=amd64] https://pkg.osquery.io/deb jessie main

apt update:
Get:25 https://pkg.osquery.io jessie/main amd64 Packages [297 B]
Err https://pkg.osquery.io jessie/main amd64 Packages
  HttpError404
Get:26 https://pkg.osquery.io jessie/main Translation-en [295 B]
Ign https://pkg.osquery.io jessie/main Translation-en
Get:27 https://pkg.osquery.io jessie/main Translation-de [295 B]
Ign https://pkg.osquery.io jessie/main Translation-de
Get:28 https://pkg.osquery.io jessie/main Translation-de_DE [298 B]
Ign https://pkg.osquery.io jessie/main Translation-de_DE
Fetched 93.6 kB in 8s (11.6 kB/s)
W: Failed to fetch https://pkg.osquery.io/deb/dists/jessie/main/binary-amd64/Packages  HttpError404
```

After:
```
deb [arch=amd64] https://pkg.osquery.io/deb deb main
```
